### PR TITLE
Expect Failure from Grammar.parse

### DIFF
--- a/lib/DOM/Tiny/CSS.pm6
+++ b/lib/DOM/Tiny/CSS.pm6
@@ -439,7 +439,7 @@ method select-one(DOM::Tiny::CSS:D: Str:D $css) returns DocumentNode:D {
 my sub _compile($css) {
     DOM::Tiny::CSS::Selector.parse($css,
         actions => DOM::Tiny::CSS::Compiler,
-    ).made // fail('syntax error in selector');
+    ) andthen .made orelse fail('syntax error in selector')
 }
 
 my multi _unescape(Str:D $value is copy) {


### PR DESCRIPTION
This is a fix for recent rakudo change
(9501edae4f73a970e3270e3b0336a7b3045d3329)

Note that the change will be reverted, but it does not hurt to adapt
this module anyway.